### PR TITLE
Add "files"-property to reduce package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   },
   "author": "Daniel Lewis",
   "license": "ISC",
-  "repository": "https://github.com/mrdaniellewis/node-stream-collect.git"
+  "repository": "https://github.com/mrdaniellewis/node-stream-collect.git",
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
The published npm package currently includes the "test"-folder that is 3M in size.
This change excludes this folder and reduces the published size significantly.